### PR TITLE
pwm: atmel-hlcdc: Fix frequency output being half of expected

### DIFF
--- a/drivers/pwm/pwm-atmel-hlcdc.c
+++ b/drivers/pwm/pwm-atmel-hlcdc.c
@@ -89,7 +89,7 @@ static int atmel_hlcdc_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
 			    atmel->errata->div1_clk_erratum)
 				continue;
 
-			if ((clk_period_ns << pres) >= state->period)
+			if ((clk_period_ns << (pres + 1)) >= state->period)
 				break;
 		}
 


### PR DESCRIPTION
The atmel-hlcdc PWM driver generates an output frequency that is
exactly half of the value requested in the device tree. For example,
a request for 1000 Hz results in a 500 Hz output.

This is caused by an incorrect prescaler calculation. The driver's
formula for the clock divider did not match the hardware, which uses
a division factor of 2^(pres + 1). The driver was missing the "+1",
causing the output period to be doubled.

This patch corrects the calculation to `2^(pres + 1)`, aligning it
with the hardware's behavior and ensuring the generated frequency is
correct.