### PR TITLE
SPI MPFS add second CS for polarfire SoC to use Fabric chip select

### DIFF
--- a/drivers/spi/spi-mpfs.c
+++ b/drivers/spi/spi-mpfs.c
@@ -21,7 +21,7 @@
 #include <linux/spi/spi.h>
 
 #define MAX_LEN				(0xffff)
-#define MAX_CS				(1)
+#define MAX_CS				(2)
 #define DEFAULT_FRAMESIZE		(8)
 #define FIFO_DEPTH			(32)
 #define CLK_GEN_MODE1_MAX		(255)


### PR DESCRIPTION
The current hard core SPI driver only allows a single CS line.  When you want to pass the CS line through the fabric then that line is actually CS 1 not CS0.  This change allows you to use the hard core SPI driver with a fabric CS line with the required change to the device tree to use the second spi CS line.

Tested on polarfire SoC only